### PR TITLE
Add missing title frontmatter to blog posts

### DIFF
--- a/_posts/2022-11-14-the-RPS-race.md
+++ b/_posts/2022-11-14-the-RPS-race.md
@@ -1,4 +1,5 @@
 ---
+title: "The RPS Race"
 permalink: /the-rps-race/
 ---
 

--- a/_posts/2023-02-10-asian-journey-in-2022.md
+++ b/_posts/2023-02-10-asian-journey-in-2022.md
@@ -1,4 +1,5 @@
 ---
+title: "Asian Journey in 2022"
 permalink: /asian-journey/
 ---
 

--- a/_posts/2024-09-23-corpus-of-artificial-texts.md
+++ b/_posts/2024-09-23-corpus-of-artificial-texts.md
@@ -1,4 +1,5 @@
 ---
+title: "Corpus of Artificial Texts"
 permalink: /coat-corpus-of-artificial-texts/
 ---
 

--- a/_posts/2024-12-22-phi-silica-small-but-mighty-small-language-model.md
+++ b/_posts/2024-12-22-phi-silica-small-but-mighty-small-language-model.md
@@ -1,4 +1,5 @@
 ---
+title: "Phi Silica: Small but Mighty Small Language Model"
 permalink: /phi-silica/
 header:
   overlay_color: "#333"

--- a/_posts/2025-06-06-how-to-automate-prompt-engineering-with-OPRO.md
+++ b/_posts/2025-06-06-how-to-automate-prompt-engineering-with-OPRO.md
@@ -1,4 +1,5 @@
 ---
+title: "How to Automate Prompt Engineering with OPRO"
 permalink: /automated-prompt-engineering/
 header:
   overlay_color: "#333"

--- a/_posts/2025-07-29-Budapest-Data-ML-Forum-2025.md
+++ b/_posts/2025-07-29-Budapest-Data-ML-Forum-2025.md
@@ -1,4 +1,5 @@
 ---
+title: "Budapest Data ML Forum 2025"
 permalink: /budapest-data-ml-forum/
 header:
   overlay_color: "#333"


### PR DESCRIPTION
<!-- This is a documentation change. -->

## Summary

Added explicit `title` frontmatter fields to six blog post files that were missing them. The titles are derived from the post filenames and match the content of each post.

## Context

The blog posts were missing the `title` field in their YAML frontmatter, which is important metadata for Jekyll-based sites. This change ensures all posts have properly defined titles in their frontmatter, improving consistency and potentially fixing display issues where the title wasn't being rendered correctly.

**Posts updated:**
- The RPS Race
- Asian Journey in 2022
- Corpus of Artificial Texts
- Phi Silica: Small but Mighty Small Language Model
- How to Automate Prompt Engineering with OPRO
- Budapest Data ML Forum 2025