### PR TITLE
Fix grammar in OpenTalks.AI blog post

### DIFF
--- a/_posts/2026-03-07-OpenTalks-AI-2026.md
+++ b/_posts/2026-03-07-OpenTalks-AI-2026.md
@@ -24,4 +24,4 @@ The session walked through several core areas:
 
 The Text Intelligence platform is designed so that new skills can be added by training new adapters without retraining the base model.
 
-It was great connecting with the AI community in Belgrade and see how rich are the advancements in Natural Language Processing in both academia and the industry in 2026.
+It was great connecting with the AI community in Belgrade and seeing how rich the advancements in Natural Language Processing in both academia and industry are in 2026.


### PR DESCRIPTION
## Summary
- "see" → "seeing" — parallel gerund with "connecting"
- "how rich are the advancements" → "how rich the advancements are" — standard word order in embedded questions
- "the industry" → "industry" — parallel with "academia"

## Test plan
- [ ] Verify post renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)